### PR TITLE
Update export constant variable names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import exampleCtx from 'context-template';
 const exampleCtx = require('context-template');
 const {contexts, constants, appContextMap} = exampleCtx;
 
-exampleCtx.CONTEXT_URL
+exampleCtx.CONTEXT_URL_V1
 // 'https://w3id.org/example/v1'
 
 // Codec term map value for CBOR-LD
@@ -47,7 +47,7 @@ exampleCtx.constants.CBORLD_CODEC_VALUE
 // 0x0..
 
 // get context data for a specific context
-exampleCtx.CONTEXT
+exampleCtx.CONTEXT_V1
 // full context object
 ```
 
@@ -57,9 +57,9 @@ applications.
 ## API
 
 The library exports the following properties:
-- `CONTEXT_URL` and `CONTEXT` (it's recommended that context repositories only export one context).
+- `CONTEXT_URL_V1` and `CONTEXT_V1` (it's recommended that context repositories only export one context).
 - `constants`: A Object that maps constants to well-known context URLs. The
-  main constant `CONTEXT_URL` may be updated from time to time to the
+  main constant `CONTEXT_URL_V1` may be updated from time to time to the
   latest context location.
 - `contexts`: A `Map` that maps URLs to full context data.
 - `appContextMap`: For use with `cborld` library.

--- a/js/constants.js
+++ b/js/constants.js
@@ -5,7 +5,7 @@
 
 module.exports = {
   CONTEXT_FILENAME: 'example-v1.jsonld',
-  CONTEXT_URL: 'https://w3id.org/example/v1',
+  CONTEXT_URL_V1: 'https://w3id.org/example/v1',
   // value between 0x0 and 0x7FFF for globally registered term codec values
   // or >= 0x8000 for app-specific local terms
   CBORLD_VALUE: 0x0

--- a/js/index.js
+++ b/js/index.js
@@ -5,18 +5,18 @@
 
 const context = require('./context');
 const constants = require('./constants');
-const {CONTEXT_URL, CBORLD_VALUE} = constants;
+const {CONTEXT_URL_V1, CBORLD_VALUE} = constants;
 
 const contexts = new Map();
-contexts.set(CONTEXT_URL, context);
+contexts.set(CONTEXT_URL_V1, context);
 
 const appContextMap = new Map();
-appContextMap.set(CONTEXT_URL, CBORLD_VALUE);
+appContextMap.set(CONTEXT_URL_V1, CBORLD_VALUE);
 
 module.exports = {
   constants,
   contexts,
   appContextMap,
-  CONTEXT_URL,
-  CONTEXT: context
+  CONTEXT_URL_V1,
+  CONTEXT_V1: context
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,8 @@ module.exports = {
       // explicitly list exports otherwise only have 'default'
       namedExports: {
         'dist/context.js': [
-          'contexts', 'constants', 'CONTEXT', 'CONTEXT_URL', 'appContextMap'
+          'contexts', 'constants', 'CONTEXT_V1', 'CONTEXT_URL_V1',
+          'appContextMap'
         ]
       }
     })

--- a/test/context.spec.js
+++ b/test/context.spec.js
@@ -6,18 +6,18 @@ chai.should();
 const {expect} = chai;
 
 const {
-  contexts, constants, appContextMap, CONTEXT_URL, CONTEXT
+  contexts, constants, appContextMap, CONTEXT_URL_V1, CONTEXT_V1
 } = require('..');
 
-const contextUrl = constants.CONTEXT_URL;
+const contextUrl = constants.CONTEXT_URL_V1;
 
 describe('Example Context', () => {
   it('constants', async () => {
     expect(appContextMap).to.exist;
     expect(constants).to.exist;
     expect(constants).to.have.property('CBORLD_VALUE');
-    expect(CONTEXT_URL).to.exist;
-    expect(CONTEXT).to.exist;
+    expect(CONTEXT_URL_V1).to.exist;
+    expect(CONTEXT_V1).to.exist;
   });
 
   it('contexts', async () => {


### PR DESCRIPTION
Renames the exported constants from `CONTEXT` to `CONTEXT_V1`, as requested previously.